### PR TITLE
Update Whisparr.sh

### DIFF
--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Whisparr/Whisparr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Whisparr/Whisparr.sh
@@ -12,7 +12,7 @@ source /opt/ibracorp/ibramenu/ibrafunc.sh
 # App Info
 app="whiasparr"                                # App Name
 title="Whisparr"                               # Readable App Title
-image="cr.hotio.dev/hotio/whisparr:nightly"    # Image and Tag
+image="ghcr.io/hotio/whisparr"    # Image and Tag
 volumes="    volumes:
       - /opt/appdata/\${APP_NAME:?err}:/config
       - /mnt/media:/media"                     # Volumes


### PR DESCRIPTION
per hotio;

 Due to scarf.sh after all this time still being on various block lists used by PiHole or other ad blockers, the use of cr.hotio.dev is halted. As you can see from the examples, ghcr.io is the new default, but if you insist on needing an older tag, you might have to pull it from docker.io (Docker Hub).