### PR TITLE
Install mdless dependency during update

### DIFF
--- a/ibraupdate.sh
+++ b/ibraupdate.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 ######################################################################
 
 ifolder="/opt/ibracorp/ibramenu"
+if ! command -v mdless >/dev/null 2>&1; then
+  apt update
+  apt install -y ruby
+  gem install mdless
+fi
 sudo bash -c "rm -rf \"$ifolder\""
 sudo bash -c "git clone -b main --single-branch https://github.com/ibracorp/ibramenu.git \"$ifolder\""
 sudo find "$ifolder" -type f -iname "*.sh" -exec chmod +x {} \;

--- a/ibraupdate.sh
+++ b/ibraupdate.sh
@@ -10,9 +10,9 @@ set -euo pipefail
 
 ifolder="/opt/ibracorp/ibramenu"
 if ! command -v mdless >/dev/null 2>&1; then
-  apt update
-  apt install -y ruby
-  gem install mdless
+  sudo apt update
+  sudo apt install -y ruby
+  sudo gem install mdless
 fi
 sudo bash -c "rm -rf \"$ifolder\""
 sudo bash -c "git clone -b main --single-branch https://github.com/ibracorp/ibramenu.git \"$ifolder\""


### PR DESCRIPTION
### Motivation
- Ensure `mdless` is present when updating so `ibramenu` does not fail its `environment_check` requirement after an update.

### Description
- Add a pre-check to `ibraupdate.sh` that installs `mdless` when missing by running `apt update`, `apt install -y ruby`, and `gem install mdless` before cloning the repo.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983df07c678832e8581433d2f252ce8)