### PR TITLE
Install Ruby build dependencies to allow mdless native gem builds

### DIFF
--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -17,7 +17,7 @@ mkdir -p "$ifolder"
 
 # Clone ibramenu
 apt update
-apt install sudo curl git ruby -y
+apt install sudo curl git ruby ruby-dev build-essential -y
 gem install mdless
 git clone -b main --single-branch https://github.com/ibracorp/ibramenu.git "$ifolder"
 find "$ifolder" -type f -iname "*.sh" -exec chmod +x {} \;

--- a/ibraupdate.sh
+++ b/ibraupdate.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 ifolder="/opt/ibracorp/ibramenu"
 if ! command -v mdless >/dev/null 2>&1; then
   sudo apt update
-  sudo apt install -y ruby
+  sudo apt install -y ruby ruby-dev build-essential
   sudo gem install mdless
 fi
 sudo bash -c "rm -rf \"$ifolder\""


### PR DESCRIPTION
### Motivation
- The update failed when installing `mdless` because the Redcarpet gem needs to compile native extensions and the system lacked Ruby headers (`ruby.h`) and build tools, causing `mkmf.rb` errors.  

### Description
- Add `ruby-dev` and `build-essential` to the `apt install` lines in `ibraupdate.sh` and `ibrainstall.sh` so Ruby development headers and toolchain are present before running `gem install mdless`.  

### Testing
- No automated tests were run for these script changes (scripts-only change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983f697a3a8832e982e281a9f6000cf)