### PR TITLE
Add ibrauninstall script and document uninstall steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ sudo chmod +x i &&\
 sudo ./i
 ```
 
+## HOW TO UNINSTALL
+
+### As root user
+
+```bash
+/opt/ibracorp/ibramenu/ibrauninstall.sh
+```
+
+### As non root user
+
+```bash
+sudo /opt/ibracorp/ibramenu/ibrauninstall.sh
+```
+
 ### From a non supported OS like unraid
 
 This is not supported and a WIP. Run the following commands.

--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -36,6 +36,13 @@ then
   echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
   source /etc/bash.bashrc
 fi
+# Add ibrauninstall as systemwide alias
+if ! grep -q ibrauninstall /etc/bash.bashrc
+then
+  insert_alias="alias ibrauninstall='sudo /opt/ibracorp/ibramenu/ibrauninstall.sh'"
+  echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
+  source /etc/bash.bashrc
+fi
 
 # Include ibrafunc for all the awesome functions
 source /opt/ibracorp/ibramenu/ibrafunc.sh
@@ -51,6 +58,7 @@ then
   else
     msgbox "Type 'ibramenu' to launch IBRAMENU"
     msgbox "Type 'ibraupdate' to update"
+    msgbox "Type 'ibrauninstall' to uninstall"
     msgbox "Please reboot after the first installation"
   fi
 fi

--- a/ibrauninstall.sh
+++ b/ibrauninstall.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+######################################################################
+# Title   : IBRAUNINSTALL - Uninstaller for IBRAMENU
+# By      : DiscDuck, Taos15
+# License : General Public License GPL-3.0-or-later
+# Another fine product brought to you by IBRACORP™
+######################################################################
+
+menu_dir="/opt/ibracorp/ibramenu"
+bashrc_file="/etc/bash.bashrc"
+
+if [ -d "$menu_dir" ]; then
+  rm -rf "$menu_dir"
+fi
+
+if [ -f "$bashrc_file" ]; then
+  sed -i "/alias ibramenu=/d" "$bashrc_file"
+  sed -i "/alias ibraupdate=/d" "$bashrc_file"
+  sed -i "/alias ibrauninstall=/d" "$bashrc_file"
+fi
+
+echo "IBRAMENU has been removed."
+echo "Restart your shell or run 'source $bashrc_file' to refresh aliases."


### PR DESCRIPTION
### Motivation

- Provide a straightforward, supported way to remove an IBRAMENU installation and associated shell aliases.
- Make uninstall discoverable by registering an `ibrauninstall` alias during installation and documenting usage in the `README.md`.

### Description

- Add `ibrauninstall.sh` which deletes the install directory at `/opt/ibracorp/ibramenu` and removes related alias lines from `/etc/bash.bashrc`.
- Register a systemwide `ibrauninstall` alias in `ibrainstall.sh` that points to `/opt/ibracorp/ibramenu/ibrauninstall.sh` and surface the command in the post-install messaging via `msgbox`.
- Document uninstall instructions for root and non-root users in `README.md` showing ` /opt/ibracorp/ibramenu/ibrauninstall.sh` and `sudo /opt/ibracorp/ibramenu/ibrauninstall.sh` respectively.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983f8e1186c832ebd724e29c1bf93c2)