### PR TITLE
Add install validation harness and make installer configurable/noninteractive

### DIFF
--- a/ibrainit.sh
+++ b/ibrainit.sh
@@ -36,7 +36,9 @@ Please take a moment and read our IBRACORP Disclaimer:
 https://docs.ibracorp.io/ibracorp/
 
 EOF
-  read -p "Press Enter to continue"
+  if [ "${IBRAMENU_NONINTERACTIVE:-0}" -ne 1 ]; then
+    read -p "Press Enter to continue"
+  fi
 }
 
 # Checklist
@@ -82,14 +84,22 @@ EOF
     "Debian GNU/Linux 10")
       echo "$distribution is considered experimental but will mostly work"
       echo "You will be asked if you want to switch the debian repositories from 'stable' to 'oldstable'. More info can be found here: https://wiki.debian.org/DebianOldStable"
-      read -p "Press Enter to continue"
+      if [ "${IBRAMENU_NONINTERACTIVE:-0}" -ne 1 ]; then
+        read -p "Press Enter to continue"
+      fi
       ;;
     "Debian GNU/Linux 11")
       echo "$distribution is considered experimental but will mostly work"
-      read -p "Press Enter to continue"
+      if [ "${IBRAMENU_NONINTERACTIVE:-0}" -ne 1 ]; then
+        read -p "Press Enter to continue"
+      fi
       ;;
     *)
-      read -p "$distribution has not been tested, would you like to continue? (y/n) " accept
+      if [ "${IBRAMENU_NONINTERACTIVE:-0}" -eq 1 ]; then
+        accept="y"
+      else
+        read -p "$distribution has not been tested, would you like to continue? (y/n) " accept
+      fi
       case "$accept" in
         [yY])
           ;;
@@ -104,16 +114,25 @@ EOF
 
 # Launch IBRAINSTALL
 install () {
-  mkdir -p /opt/ibracorp
-  wget -qO /opt/ibracorp/ibrainstall.sh https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainstall.sh
-  chmod +x /opt/ibracorp/ibrainstall.sh
-  /opt/ibracorp/ibrainstall.sh $1
+  local install_root="/opt/ibracorp"
+  local installer_path="${install_root}/ibrainstall.sh"
+  local installer_url="${IBRAMENU_INSTALLER_URL:-https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainstall.sh}"
+  mkdir -p "$install_root"
+  if [ -n "${IBRAMENU_INSTALLER_PATH-}" ]; then
+    cp "$IBRAMENU_INSTALLER_PATH" "$installer_path"
+  else
+    wget -qO "$installer_path" "$installer_url"
+  fi
+  chmod +x "$installer_path"
+  "$installer_path" $1
 }
 
 # Execute
 if [ -z "${1-}" ]
 then
-  disclaimer
+  if [ "${IBRAMENU_NONINTERACTIVE:-0}" -ne 1 ]; then
+    disclaimer
+  fi
 fi
 if [ -n "${2-}" ]
 then

--- a/scripts/validate-install.sh
+++ b/scripts/validate-install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temp_root="$(mktemp -d)"
+cleanup() {
+  rm -rf "$temp_root"
+}
+trap cleanup EXIT
+
+export IBRAMENU_PREFIX="${temp_root}/ibracorp"
+export IBRAMENU_INSTALL_ROOT="${IBRAMENU_PREFIX}/ibramenu"
+export IBRAMENU_CLONE_SOURCE="${repo_root}"
+export IBRAMENU_CLONE_BRANCH="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
+export IBRAMENU_SKIP_PACKAGES=1
+export IBRAMENU_SKIP_ALIASES=1
+export IBRAMENU_SKIP_MOTD=1
+
+printf "Validating install into %s\n" "$IBRAMENU_INSTALL_ROOT"
+"${repo_root}/ibrainstall.sh"
+
+test -d "$IBRAMENU_INSTALL_ROOT"
+test -x "$IBRAMENU_INSTALL_ROOT/ibramenu.sh"
+test -x "$IBRAMENU_INSTALL_ROOT/ibraupdate.sh"
+test -x "$IBRAMENU_INSTALL_ROOT/ibrauninstall.sh"
+test -d "$IBRAMENU_INSTALL_ROOT/MenuOptions"
+
+printf "Install validation complete.\n"


### PR DESCRIPTION
### Motivation
- Enable automated, noninteractive validation of the installer for CI and local testing.
- Allow test-time overrides for install paths and clone source/branch so installs can run against the working tree.
- Provide flags to skip package installation, alias injection, and MOTD to avoid touching system state when testing.

### Description
- Add environment-driven configuration to `ibrainstall.sh` with `IBRAMENU_PREFIX`, `IBRAMENU_INSTALL_ROOT`, `IBRAMENU_CLONE_SOURCE`, `IBRAMENU_CLONE_BRANCH`, and skip flags `IBRAMENU_SKIP_PACKAGES`, `IBRAMENU_SKIP_ALIASES`, and `IBRAMENU_SKIP_MOTD` so installs can be redirected and made idempotent for tests.
- Make package installation, git clone branch/source, alias creation, and MOTD sourcing conditional on the new flags, and ensure aliases reference the install root (`ifolder`).
- Update `ibrainit.sh` to support noninteractive runs via `IBRAMENU_NONINTERACTIVE`, allow using a provided installer path or URL via `IBRAMENU_INSTALLER_PATH`/`IBRAMENU_INSTALLER_URL`, and skip prompts or default to accept in noninteractive mode.
- Add `scripts/validate-install.sh`, a small validation harness that creates a temporary install root, sets the test override env vars, runs the local `ibrainstall.sh`, and asserts the installed layout and executables exist.

### Testing
- Ran `scripts/validate-install.sh` which cloned the repository into a temporary install root and completed with "Install validation complete." indicating the smoke test passed.
- The validation script checks that the install directory, `ibramenu.sh`, `ibraupdate.sh`, `ibrauninstall.sh`, and `MenuOptions` are present and executable, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983fafc3a78832e95b3e9384404f214)