### PR TITLE
Wrap /etc/bash.bashrc sourcing with `set +u`/`set -u` guards

### DIFF
--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -38,21 +38,27 @@ if [ "$skip_aliases" -ne 1 ]; then
   then
     insert_alias="alias ibramenu='sudo ${ifolder}/ibramenu.sh'"
     echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
+    set +u
     source /etc/bash.bashrc
+    set -u
   fi
   # Add ibraupdate as systemwide alias
   if ! grep -q ibraupdate /etc/bash.bashrc
   then
     insert_alias="alias ibraupdate='sudo ${ifolder}/ibraupdate.sh'"
     echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
+    set +u
     source /etc/bash.bashrc
+    set -u
   fi
   # Add ibrauninstall as systemwide alias
   if ! grep -q ibrauninstall /etc/bash.bashrc
   then
     insert_alias="alias ibrauninstall='sudo ${ifolder}/ibrauninstall.sh'"
     echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
+    set +u
     source /etc/bash.bashrc
+    set -u
   fi
 fi
 


### PR DESCRIPTION
### Motivation
- Avoid sourcing `/etc/bash.bashrc` while `set -u` (nounset) is active which can produce unset-variable errors during the installer alias setup.  

### Description
- In `ibrainstall.sh` wrap each `source /etc/bash.bashrc` call in the alias setup blocks with a temporary `set +u`/`set -u` guard so the file is sourced safely without changing surrounding error semantics.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983fefcfb08832ea1973d3c8628decb)