### PR TITLE
Skip mdless docs during install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN \
   zsh \
   mc \
   sudo && \
-  gem install mdless 
+  gem install mdless --no-document 
 
 ## Install Docker
 RUN \
@@ -74,5 +74,4 @@ RUN \
   /tmp/* \
   /var/lib/apt/lists/* \
   /var/tmp/*
-
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -25,7 +25,7 @@ RUN \
     net-tools \
     netcat \
     sudo && \
-    gem install mdless && \ 
+    gem install mdless --no-document && \ 
     find /opt/ibracorp/ibramenu -type f -iname "*.sh" -exec chmod +x {} \; && \
   echo "**** clean up ****" && \
   apt-get clean && \

--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -27,7 +27,7 @@ mkdir -p "$ifolder"
 if [ "$skip_packages" -ne 1 ]; then
   apt update
   apt install sudo curl git ruby ruby-dev build-essential -y
-  gem install mdless
+  gem install mdless --no-document
 fi
 git clone -b "$clone_branch" --single-branch "$clone_source" "$ifolder"
 find "$ifolder" -type f -iname "*.sh" -exec chmod +x {} \;

--- a/ibraupdate.sh
+++ b/ibraupdate.sh
@@ -12,7 +12,7 @@ ifolder="/opt/ibracorp/ibramenu"
 if ! command -v mdless >/dev/null 2>&1; then
   sudo apt update
   sudo apt install -y ruby ruby-dev build-essential
-  sudo gem install mdless
+  sudo gem install mdless --no-document
 fi
 sudo bash -c "rm -rf \"$ifolder\""
 sudo bash -c "git clone -b main --single-branch https://github.com/ibracorp/ibramenu.git \"$ifolder\""


### PR DESCRIPTION
### Motivation
- Avoid installing Ruby gem documentation to speed up installs and ensure consistent behavior across installer, updater, and container builds when installing `mdless`.

### Description
- Add the `--no-document` flag to `gem install mdless` invocations in `ibrainstall.sh`, `ibraupdate.sh`, `Dockerfile`, and `Dockerfile-dev` to skip doc generation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983feff3954832e9c627eb81805af75)