### PR TITLE
Add PATH launchers for ibra commands

### DIFF
--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -16,6 +16,7 @@ clone_branch="${IBRAMENU_CLONE_BRANCH:-main}"
 skip_packages="${IBRAMENU_SKIP_PACKAGES:-0}"
 skip_aliases="${IBRAMENU_SKIP_ALIASES:-0}"
 skip_motd="${IBRAMENU_SKIP_MOTD:-0}"
+launcher_dir="${IBRAMENU_LAUNCHER_DIR:-/usr/local/bin}"
 
 # Check for existing ibramenu folder and clean up if needed
 if [ -d "$ifolder" ]; then
@@ -31,6 +32,23 @@ if [ "$skip_packages" -ne 1 ]; then
 fi
 git clone -b "$clone_branch" --single-branch "$clone_source" "$ifolder"
 find "$ifolder" -type f -iname "*.sh" -exec chmod +x {} \;
+
+# Install launchers into a directory on PATH
+install_launcher() {
+  local launcher_name="$1"
+  local target_script="$2"
+
+  mkdir -p "$launcher_dir"
+  cat <<EOF | tee "${launcher_dir}/${launcher_name}" > /dev/null
+#!/bin/bash
+exec sudo "${target_script}" "\$@"
+EOF
+  chmod +x "${launcher_dir}/${launcher_name}"
+}
+
+install_launcher "ibramenu" "${ifolder}/ibramenu.sh"
+install_launcher "ibraupdate" "${ifolder}/ibraupdate.sh"
+install_launcher "ibrauninstall" "${ifolder}/ibrauninstall.sh"
 
 # Add ibramenu as systemwide alias
 if [ "$skip_aliases" -ne 1 ]; then


### PR DESCRIPTION
### Motivation
- Aliases added to `/etc/bash.bashrc` do not always work in login shells or persist reliably after reboot, so installable launchers on `PATH` are needed.
- Launchers should execute the actual scripts under `/opt/ibracorp/ibramenu/` and be executable so `ibramenu`, `ibraupdate`, and `ibrauninstall` work systemwide.

### Description
- Added a configurable `launcher_dir` (`IBRAMENU_LAUNCHER_DIR`, default `/usr/local/bin`) to `ibrainstall.sh`.
- Implemented `install_launcher()` which creates an executable wrapper that `exec sudo "${target_script}" "$@"` and writes it to `"${launcher_dir}/${launcher_name}"`.
- Installed wrappers for `ibramenu`, `ibraupdate`, and `ibrauninstall` that reference `${ifolder}/ibramenu.sh`, `${ifolder}/ibraupdate.sh`, and `${ifolder}/ibrauninstall.sh` respectively.
- Kept the existing alias logic in `/etc/bash.bashrc` so behavior is preserved for environments that rely on aliases.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698401ea4a68832eaf1dc0d45fd28165)