### PR TITLE
Add /etc/profile.d/ibramenu.sh for login-shell aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,13 @@ RUN \
   touch /opt/ibracorp/IBRADISCLAIMER && \
   echo "**** Creating Inbramenu alias ****" && \
   echo IBRADISCLAIMER=accepted > /opt/ibracorp/IBRADISCLAIMER && \
-  echo "alias ibramenu='sudo /opt/ibracorp/ibramenu/ibramenu.sh'" | tee -a /etc/bash.bashrc > /dev/null && \
+  printf '%s\n' \
+    '# IBRAMENU aliases loaded by /etc/profile for login shells.' \
+    "alias ibramenu='sudo /opt/ibracorp/ibramenu/ibramenu.sh'" \
+    "alias ibraupdate='sudo /opt/ibracorp/ibramenu/ibraupdate.sh'" \
+    "alias ibrauninstall='sudo /opt/ibracorp/ibramenu/ibrauninstall.sh'" \
+    | tee /etc/profile.d/ibramenu.sh > /dev/null && \
+  chmod 0644 /etc/profile.d/ibramenu.sh && \
   echo "**** clean up ****" && \
   apt-get clean && \
   rm -rf \
@@ -74,4 +80,3 @@ RUN \
   /tmp/* \
   /var/lib/apt/lists/* \
   /var/tmp/*
-

--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -16,6 +16,7 @@ clone_branch="${IBRAMENU_CLONE_BRANCH:-main}"
 skip_packages="${IBRAMENU_SKIP_PACKAGES:-0}"
 skip_aliases="${IBRAMENU_SKIP_ALIASES:-0}"
 skip_motd="${IBRAMENU_SKIP_MOTD:-0}"
+profile_alias_file="/etc/profile.d/ibramenu.sh"
 
 # Check for existing ibramenu folder and clean up if needed
 if [ -d "$ifolder" ]; then
@@ -34,32 +35,13 @@ find "$ifolder" -type f -iname "*.sh" -exec chmod +x {} \;
 
 # Add ibramenu as systemwide alias
 if [ "$skip_aliases" -ne 1 ]; then
-  if ! grep -q ibramenu /etc/bash.bashrc
-  then
-    insert_alias="alias ibramenu='sudo ${ifolder}/ibramenu.sh'"
-    echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
-    set +u
-    source /etc/bash.bashrc
-    set -u
-  fi
-  # Add ibraupdate as systemwide alias
-  if ! grep -q ibraupdate /etc/bash.bashrc
-  then
-    insert_alias="alias ibraupdate='sudo ${ifolder}/ibraupdate.sh'"
-    echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
-    set +u
-    source /etc/bash.bashrc
-    set -u
-  fi
-  # Add ibrauninstall as systemwide alias
-  if ! grep -q ibrauninstall /etc/bash.bashrc
-  then
-    insert_alias="alias ibrauninstall='sudo ${ifolder}/ibrauninstall.sh'"
-    echo $insert_alias | sudo tee -a /etc/bash.bashrc > /dev/null
-    set +u
-    source /etc/bash.bashrc
-    set -u
-  fi
+  sudo tee "$profile_alias_file" > /dev/null <<EOF
+# IBRAMENU aliases loaded by /etc/profile for login shells.
+alias ibramenu='sudo ${ifolder}/ibramenu.sh'
+alias ibraupdate='sudo ${ifolder}/ibraupdate.sh'
+alias ibrauninstall='sudo ${ifolder}/ibrauninstall.sh'
+EOF
+  sudo chmod 0644 "$profile_alias_file"
 fi
 
 # Include ibrafunc for all the awesome functions

--- a/ibrauninstall.sh
+++ b/ibrauninstall.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 menu_dir="/opt/ibracorp/ibramenu"
 bashrc_file="/etc/bash.bashrc"
+profile_alias_file="/etc/profile.d/ibramenu.sh"
 
 if [ -d "$menu_dir" ]; then
   rm -rf "$menu_dir"
@@ -20,6 +21,9 @@ if [ -f "$bashrc_file" ]; then
   sed -i "/alias ibraupdate=/d" "$bashrc_file"
   sed -i "/alias ibrauninstall=/d" "$bashrc_file"
 fi
+if [ -f "$profile_alias_file" ]; then
+  rm -f "$profile_alias_file"
+fi
 
 echo "IBRAMENU has been removed."
-echo "Restart your shell or run 'source $bashrc_file' to refresh aliases."
+echo "Restart your login shell or run 'source /etc/profile' to refresh aliases."


### PR DESCRIPTION
### Motivation
- Ensure system-wide aliases for IBRAMENU are available to login shells without relying on interactive-only shell startup files like `/etc/bash.bashrc`.
- Make the same behavior available in the container image and ensure uninstall cleans up the created file.

### Description
- Update the installer `ibrainstall.sh` to write aliases to `/etc/profile.d/ibramenu.sh` and set permissions with `chmod 0644` instead of appending to `/etc/bash.bashrc` and sourcing it.
- Update the Dockerfile to create `/etc/profile.d/ibramenu.sh` in the image (using `tee`/`printf`) and set permissions so login shells inside the container pick up the aliases.
- Update the uninstaller `ibrauninstall.sh` to remove `/etc/profile.d/ibramenu.sh` during uninstall and adjust the messaging to recommend restarting a login shell or running `source /etc/profile`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698401eeecfc832ea2273209503f8dda)