### PR TITLE
Fix launcher directory default for installer

### DIFF
--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -17,6 +17,7 @@ skip_packages="${IBRAMENU_SKIP_PACKAGES:-0}"
 skip_aliases="${IBRAMENU_SKIP_ALIASES:-0}"
 skip_motd="${IBRAMENU_SKIP_MOTD:-0}"
 profile_alias_file="/etc/profile.d/ibramenu.sh"
+launcher_dir="${IBRAMENU_LAUNCHER_DIR:-/usr/local/bin}"
 
 # Check for existing ibramenu folder and clean up if needed
 if [ -d "$ifolder" ]; then

--- a/scripts/validate-install.sh
+++ b/scripts/validate-install.sh
@@ -10,6 +10,7 @@ trap cleanup EXIT
 
 export IBRAMENU_PREFIX="${temp_root}/ibracorp"
 export IBRAMENU_INSTALL_ROOT="${IBRAMENU_PREFIX}/ibramenu"
+export IBRAMENU_LAUNCHER_DIR="${temp_root}/launchers"
 export IBRAMENU_CLONE_SOURCE="${repo_root}"
 export IBRAMENU_CLONE_BRANCH="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
 export IBRAMENU_SKIP_PACKAGES=1


### PR DESCRIPTION
### Motivation
- Prevent the installer from failing due to an unbound `launcher_dir` in test/noninteractive environments and allow the launcher install location to be overridden via an environment variable.

### Description
- Add `launcher_dir="${IBRAMENU_LAUNCHER_DIR:-/usr/local/bin}"` to `ibrainstall.sh` and export `IBRAMENU_LAUNCHER_DIR` to a temporary `launchers` directory in `scripts/validate-install.sh` so tests install launchers into the workspace.

### Testing
- Ran `bash scripts/validate-install.sh` and the validation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698404485814832e8e17a5b67306c9bf)