### PR TITLE
Add Table of Contents and normalize README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@
 This README is actively maintained alongside the documentation. You can also reference the
 documentation page below for deeper guides and walkthroughs.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Uninstall](#uninstall)
+- [Docker Usage](#docker-usage)
+- [Debug Mode](#debug-mode)
+- [Network Override](#network-override)
+- [Support](#support)
+
 ## Suggested Improvements & Roadmap
 
 Below is a curated list of improvements to make IBRAMENU best-in-class for what it does.
@@ -37,7 +46,7 @@ Development has begun again, with ongoing updates focused on reliability and usa
 running this in production, keep pinning versions and review updates as they land. Community
 contributions are welcome.
 
-## HOW TO INSTALL
+## Installation
 
 ### As root user
 
@@ -55,7 +64,7 @@ sudo chmod +x i &&\
 sudo ./i
 ```
 
-## HOW TO UNINSTALL
+## Uninstall
 
 ### As root user
 
@@ -68,6 +77,8 @@ sudo ./i
 ```bash
 sudo /opt/ibracorp/ibramenu/ibrauninstall.sh
 ```
+
+## Docker Usage
 
 ### From a non supported OS like unraid
 
@@ -91,16 +102,6 @@ docker run -it ibramenu /bin/bash
 
 On launch, IBRAMENU validates that Docker, the Docker Compose plugin, and `mdless` are available,
 and that the Docker daemon is accessible. Fix any missing dependencies before continuing.
-
-### Debug mode
-
-To enable additional logging, set `IBRAMENU_DEBUG=1`. Logs are written to
-`/opt/appdata/ibramenu/ibramenu.log`.
-
-### Docker network override
-
-By default IBRAMENU uses the network defined in `.profile` (`ibranet`). You can override this by
-exporting `IBRAMENU_DOCKER_NETWORK` before launching the menu.
 
 ### Compose File Example
 
@@ -133,8 +134,17 @@ docker exec -it ibramenu bash
 ibramenu
 ```
 
+## Debug Mode
 
+To enable additional logging, set `IBRAMENU_DEBUG=1`. Logs are written to
+`/opt/appdata/ibramenu/ibramenu.log`.
 
+## Network Override
+
+By default IBRAMENU uses the network defined in `.profile` (`ibranet`). You can override this by
+exporting `IBRAMENU_DOCKER_NETWORK` before launching the menu.
+
+## Support
 
 [![Install](https://img.shields.io/badge/Install-IBRAMENU-brightgreen?style=plastic)](https://docs.ibracorp.io/ibramenu)
 Make requests here: <https://feedback.ibracorp.io/ibramenu>


### PR DESCRIPTION
### Motivation
- Improve README navigation by adding a short Table of Contents near the top so GitHub autogenerates anchors for major sections.
- Make section headings stable and consistent so the TOC links resolve correctly.

### Description
- Added a `## Table of Contents` block linking to `Installation`, `Uninstall`, `Docker Usage`, `Debug Mode`, `Network Override`, and `Support` near the top of `README.md`.
- Normalized heading text by renaming headings such as `HOW TO INSTALL` -> `Installation` and `HOW TO UNINSTALL` -> `Uninstall` to match GitHub anchor generation.
- Moved and adjusted `Debug Mode`, `Network Override`, and `Support` sections so anchors align with the TOC.
- Modified file: `README.md` (documentation-only change).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984082cc618832eb996b8709ade197b)