### PR TITLE
Add Supported Platforms & Prerequisites to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ sudo chmod +x i &&\
 sudo ./i
 ```
 
+## Supported Platforms & Prerequisites
+
+### Supported OS targets
+- Ubuntu 22.04 LTS (recommended)
+- Ubuntu 20.04 LTS
+
+### Minimum container tooling
+- Docker Engine 24.0+
+- Docker Compose plugin 2.20+
+
+### Required tools
+- `mdless` (used by pre-flight checks)
+- `bash`, `curl`/`wget`, and standard GNU utilities available on Ubuntu
+
+### Non-supported platforms
+Platforms like Unraid are not officially supported. You may get IBRAMENU running via the
+container workflow below, but expect limited troubleshooting support and potential feature gaps
+around OS detection, permissions, and path assumptions.
+
 ## HOW TO UNINSTALL
 
 ### As root user


### PR DESCRIPTION
### Motivation
- Provide clear guidance on supported OS targets, container tooling minimums, and required utilities so users can pass pre-flight checks and reduce install issues.

### Description
- Add a new `Supported Platforms & Prerequisites` section to `README.md` that lists supported OS targets (Ubuntu 22.04 LTS and 20.04 LTS), minimum container tooling (`Docker Engine 24.0+` and `Docker Compose plugin 2.20+`), required tools (including `mdless`), and a note about non-supported platforms such as Unraid and expected limitations.
- Change is a documentation-only update applied to `README.md` (19 insertions).

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69840830d4b8832ebffacd909e40d36e)