### PR TITLE
Fix install command continuations and add note to inspect `ibrainit.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,25 @@ contributions are welcome.
 ### As root user
 
 ```bash
-wget -qO ./i https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainit.sh &&\ 
-chmod +x i &&\ 
+wget -qO ./i https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainit.sh &&\
+chmod +x i &&\
 ./i
+```
+
+The `ibrainit.sh` script bootstraps the install (downloads dependencies and configures the
+application). Inspect it before running if you’d like, for example:
+
+```bash
+curl -L https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainit.sh | less
+# or
+wget -qO- https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainit.sh | less
 ```
 
 ### As non root user
 
 ``` bash
-sudo wget -qO ./i https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainit.sh &&\ 
-sudo chmod +x i &&\ 
+sudo wget -qO ./i https://raw.githubusercontent.com/ibracorp/ibramenu/main/ibrainit.sh &&\
+sudo chmod +x i &&\
 sudo ./i
 ```
 


### PR DESCRIPTION
### Motivation
- Clean up the multiline install snippets to remove trailing spaces after `&&\` and make root and non-root flows consistent, and add guidance about what `ibrainit.sh` does and how to inspect it prior to running.

### Description
- Removed trailing spaces after `&&\` in the install examples and normalized the root and non-root command blocks to match.
- Added a short note explaining that `ibrainit.sh` bootstraps the install and included examples showing how to inspect the script (`curl -L ... | less` and `wget -qO- ... | less`) before execution.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698408317dc4832e8b1d2fb100681f87)