### PR TITLE
Add Sycotix as primary author in script headers

### DIFF
--- a/MenuOptions/Submenu Basic Functions/Power down system/Power down system.sh
+++ b/MenuOptions/Submenu Basic Functions/Power down system/Power down system.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Power Down
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Reboot/Reboot.sh
+++ b/MenuOptions/Submenu Basic Functions/Reboot/Reboot.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Reboot
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/General Information/General Information.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/General Information/General Information.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Neofetch
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/List Docker Container/List Docker Container.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/List Docker Container/List Docker Container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : List all Docker Container
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Memory Information/Memory Information.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Memory Information/Memory Information.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Display Memory Information
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Rootkit Check/Rootkit Check.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Rootkit Check/Rootkit Check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Rootkit Check
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Show Video Adapters/Show Video Adapters.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Show Video Adapters/Show Video Adapters.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Show Video Adapters
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/All Tests/All Tests.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/All Tests/All Tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Benchmark - All Tests
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/Disk Performance/Disk Performance.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/Disk Performance/Disk Performance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Benchmark - Disk Performance
-# By      : DiscDuck
+# By      : Sycotix, DiscDuck
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/Network Performance/Network Performance.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/Network Performance/Network Performance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Benchmark - Network Performance
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/System Performance (older Version)/System Performance (older Version).sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/System Performance (older Version)/System Performance (older Version).sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Benchmark - System Performance (older Version)
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/System Performance/System Performance.sh
+++ b/MenuOptions/Submenu Basic Functions/Submenu System Information/Submenu Benchmarks/System Performance/System Performance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Benchmark - System Performance
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Install Steps/All Steps in One/All Steps in One.sh
+++ b/MenuOptions/Submenu Basic Install Steps/All Steps in One/All Steps in One.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : All Steps
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Install Steps/General Tools/General Tools.sh
+++ b/MenuOptions/Submenu Basic Install Steps/General Tools/General Tools.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Install General Tools
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Install Steps/Install Docker Compose/Install Docker Compose.sh
+++ b/MenuOptions/Submenu Basic Install Steps/Install Docker Compose/Install Docker Compose.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Install Docker Compose
-# By      : ibros
+# By      : Sycotix, ibros
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Install Steps/Install Docker/Install Docker.sh
+++ b/MenuOptions/Submenu Basic Install Steps/Install Docker/Install Docker.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Install Docker
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Install Steps/Install Node/Install Node.sh
+++ b/MenuOptions/Submenu Basic Install Steps/Install Node/Install Node.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Install Docker Compose
-# By      : Taos15
+# By      : Sycotix, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Basic Install Steps/Update and Upgrade/Update and Upgrade.sh
+++ b/MenuOptions/Submenu Basic Install Steps/Update and Upgrade/Update and Upgrade.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Update and Upgrade
-# By      : DiscDuck
+# By      : Sycotix, DiscDuck
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Docker/Basic Docker Control/Basic Docker Control.sh
+++ b/MenuOptions/Submenu Docker/Basic Docker Control/Basic Docker Control.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Basic Docker Control
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Docker/Portainer/Portainer.sh
+++ b/MenuOptions/Submenu Docker/Portainer/Portainer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Portainer
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Docker/Submenu Watchtower/Watchtower install on schedule/Watchtower install on schedule.sh
+++ b/MenuOptions/Submenu Docker/Submenu Watchtower/Watchtower install on schedule/Watchtower install on schedule.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Install Watchtower on schedule
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP   ^d
 ######################################################################

--- a/MenuOptions/Submenu Docker/Submenu Watchtower/Watchtower manual run/Watchtower manual run.sh
+++ b/MenuOptions/Submenu Docker/Submenu Watchtower/Watchtower manual run/Watchtower manual run.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Watchtower manual run
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Extra Menus/Supporter Menu/Supporter Menu.sh
+++ b/MenuOptions/Submenu Extra Menus/Supporter Menu/Supporter Menu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : IBRAMENU Supporter Menu
-# By      : DiscDuck
+# By      : Sycotix, DiscDuck
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Media SMB mount/Media SMB mount.sh
+++ b/MenuOptions/Submenu Media Services/Media SMB mount/Media SMB mount.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Create Media SMB mount
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Download Services/SABnzbd/SABnzbd.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Download Services/SABnzbd/SABnzbd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install SABnzbd
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Download Services/qbittorrent-vpn/qbittorrent-vpn.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Download Services/qbittorrent-vpn/qbittorrent-vpn.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Qbittorrent-vpn
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Download Services/qbittorrent/qbittorrent.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Download Services/qbittorrent/qbittorrent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Qbittorrent
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Players/Jellyfin/Jellyfin.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Players/Jellyfin/Jellyfin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Jellyfin
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Players/Plex-Meta-Manager/Plex-Meta-Manager.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Players/Plex-Meta-Manager/Plex-Meta-Manager.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Komga
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Players/Plex/Plex.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Players/Plex/Plex.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Plex
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Players/emby/emby.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Players/emby/emby.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Emby
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Requester/Ombi/Ombi.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Requester/Ombi/Ombi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Ombi
-# By      : DiscDuck
+# By      : Sycotix, DiscDuck
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Requester/Overseerr/Overseerr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Requester/Overseerr/Overseerr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Overseerr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Requester/Wizarr/Wizarr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Requester/Wizarr/Wizarr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Wizarr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Media Requester/jellyseerr/jellyseerr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Media Requester/jellyseerr/jellyseerr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Jellyseer
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Lidarr/Lidarr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Lidarr/Lidarr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Lidarr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Prowlarr/Prowlarr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Prowlarr/Prowlarr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Prowlarr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Radarr 4K/Radarr 4K.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Radarr 4K/Radarr 4K.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Radarr 4K
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Radarr/Radarr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Radarr/Radarr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Radarr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Sonarr 4K/Sonarr 4K.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Sonarr 4K/Sonarr 4K.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Sonarr 4K
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Sonarr/Sonarr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Sonarr/Sonarr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Sonarr
-# By      : DiscDuck
+# By      : Sycotix, DiscDuck
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Whisparr/Whisparr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Whisparr/Whisparr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Whisparr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Tools/Tautulli/Tautulli.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Tools/Tautulli/Tautulli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Tautulli
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Media Services/Submenu Tools/unpackerr/unpackerr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu Tools/unpackerr/unpackerr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Unpackerr
-# By      : DiscDuck
+# By      : Sycotix, DiscDuck
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/AdGuard Home/AdGuard Home.sh
+++ b/MenuOptions/Submenu Networking/AdGuard Home/AdGuard Home.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install AdGuard Home
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/Dockerproxy/Dockerproxy.sh
+++ b/MenuOptions/Submenu Networking/Dockerproxy/Dockerproxy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Dockerproxy
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/Nginx Proxy Manager/Nginx Proxy Manager.sh
+++ b/MenuOptions/Submenu Networking/Nginx Proxy Manager/Nginx Proxy Manager.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Nginx Proxy Manager
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/Submenu Cloudflare/Create Tunnel/Create Tunnel.sh
+++ b/MenuOptions/Submenu Networking/Submenu Cloudflare/Create Tunnel/Create Tunnel.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Cloudflare Tunnel Installer
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/Submenu Cloudflare/Delete Tunnel/Delete Tunnel.sh
+++ b/MenuOptions/Submenu Networking/Submenu Cloudflare/Delete Tunnel/Delete Tunnel.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : Cloudflare Tunnel Deletion
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/Swag/Swag.sh
+++ b/MenuOptions/Submenu Networking/Swag/Swag.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Swag
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/Traefik/Traefik.sh
+++ b/MenuOptions/Submenu Networking/Traefik/Traefik.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Traefik
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Networking/Uptime Kuma/Uptime Kuma.sh
+++ b/MenuOptions/Submenu Networking/Uptime Kuma/Uptime Kuma.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Uptime Kuma
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Other/Submenu Games/Submenu Minecraft/Submenu FTB Direwolf20 1.19/Install FTB Direwolf20 1.19/Install FTB Direwolf20 1.19.sh
+++ b/MenuOptions/Submenu Other/Submenu Games/Submenu Minecraft/Submenu FTB Direwolf20 1.19/Install FTB Direwolf20 1.19/Install FTB Direwolf20 1.19.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Minecraft Direwolf20 1.19
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Other/Submenu Games/Submenu Minecraft/Submenu FTB Direwolf20 1.19/Start FTB Direwolf20 1.19/Start FTB Direwolf20 1.19.sh
+++ b/MenuOptions/Submenu Other/Submenu Games/Submenu Minecraft/Submenu FTB Direwolf20 1.19/Start FTB Direwolf20 1.19/Start FTB Direwolf20 1.19.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Minecraft Direwolf20 1.19
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Other/Submenu Manga/Komf/Komf.sh
+++ b/MenuOptions/Submenu Other/Submenu Manga/Komf/Komf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Komf
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Other/Submenu Manga/Komga/Komga.sh
+++ b/MenuOptions/Submenu Other/Submenu Manga/Komga/Komga.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Komga
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Security/Authentik/Authentik.sh
+++ b/MenuOptions/Submenu Security/Authentik/Authentik.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Authentik
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Security/Clamav/Clamav.sh
+++ b/MenuOptions/Submenu Security/Clamav/Clamav.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Komga
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Security/Vaultwarden/Vaultwarden.sh
+++ b/MenuOptions/Submenu Security/Vaultwarden/Vaultwarden.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Vaultwarden
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Tools/Code-Server/Code-Server.sh
+++ b/MenuOptions/Submenu Tools/Code-Server/Code-Server.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Code-Server
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Tools/Dashy/Dashy.sh
+++ b/MenuOptions/Submenu Tools/Dashy/Dashy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Dashy
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Tools/Dozzle/Dozzle.sh
+++ b/MenuOptions/Submenu Tools/Dozzle/Dozzle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Dozzle
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Tools/FreshRSS/FreshRSS.sh
+++ b/MenuOptions/Submenu Tools/FreshRSS/FreshRSS.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Komga
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Tools/Homarr/Homarr.sh
+++ b/MenuOptions/Submenu Tools/Homarr/Homarr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Homarr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Tools/Linkwarden/Linkwarden.sh
+++ b/MenuOptions/Submenu Tools/Linkwarden/Linkwarden.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Linkwarden
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/MenuOptions/Submenu Tools/Organizr/Organizr.sh
+++ b/MenuOptions/Submenu Tools/Organizr/Organizr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : Install Organizr
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/ibrafunc.sh
+++ b/ibrafunc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ######################################################################
 # Title   : IBRAFUNC - IBRAMENU functions
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################
@@ -221,7 +221,7 @@ ibramotd() {
 #!/bin/bash
 ######################################################################
 # Title   : IBRACORP MOTD
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP   ^d
 ######################################################################

--- a/ibrainit.sh
+++ b/ibrainit.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ######################################################################
 # Title   : Beachhead - Initial Installer for IBRAMENU
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/ibrainstall.sh
+++ b/ibrainstall.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ######################################################################
 # Title   : IBRAINSTALL Installer and Updater for IBRAMENU
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/ibramenu.sh
+++ b/ibramenu.sh
@@ -2,7 +2,7 @@
 
 ######################################################################
 # Title   : IBRAMENU
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/ibrauninstall.sh
+++ b/ibrauninstall.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ######################################################################
 # Title   : IBRAUNINSTALL - Uninstaller for IBRAMENU
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################

--- a/ibraupdate.sh
+++ b/ibraupdate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ######################################################################
 # Title   : Beachhead - Initial Installer for IBRAMENU
-# By      : DiscDuck, Taos15
+# By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
 ######################################################################


### PR DESCRIPTION
### Motivation
- Ensure the project attribution lists `Sycotix` first wherever the `# By` header appears across scripts.
- Keep existing co-authors intact while making `Sycotix` the primary listed author for consistency.

### Description
- Updated the `# By` header lines in many shell scripts (core files like `ibramenu.sh`, `ibrafunc.sh`, `ibrainstall.sh`, `ibraupdate.sh`, `ibrauninstall.sh` and numerous files under `MenuOptions/`) to prepend `Sycotix` to existing attributions.
- Normalized single-author headers (e.g. `DiscDuck`, `Taos15`, `ibros`) to include `Sycotix` as the first entry where appropriate.
- Changes were applied with a small automation script to perform safe textual replacements only in lines containing `# By`.
- Staged and committed the updated files as a single cohesive change set updating 72 files.

### Testing
- Ran `rg` to locate existing `DiscDuck`, `Taos15`, and `# By` occurrences before and after the change to verify all targets were found and updated successfully.
- Executed the Python replacement script to perform updates and re-ran `rg` to confirm no remaining unmatched headers lacked `Sycotix`.
- Inspected sample files with `nl` to validate header formatting and ran `git commit` which succeeded reporting `72 files changed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69840b8352ec832ea4096d875a674f32)