### PR TITLE
Fix multiple bugs found during codebase review and launch testing

### DIFF
--- a/MenuOptions/Submenu Basic Install Steps/General Tools/General Tools.sh
+++ b/MenuOptions/Submenu Basic Install Steps/General Tools/General Tools.sh
@@ -15,7 +15,7 @@ install_tools () {
    # Python 3 (pip)
    apt install python3-pip -y
    # Pip psutil
-   apt-get install gcc python3-dev
+   apt-get install gcc python3-dev -y
    pip install --no-binary :all: psutil
    # Google Download
    pip3 install gdown

--- a/MenuOptions/Submenu Basic Install Steps/Install Docker/Install Docker.sh
+++ b/MenuOptions/Submenu Basic Install Steps/Install Docker/Install Docker.sh
@@ -10,8 +10,8 @@
 install_docker () {
   sudo apt-get remove docker docker-engine docker.io containerd runc
   sudo apt-get update
-  sudo apt-get install ca-certificates curl gnupg lsb-release
-  sudo rm /usr/share/keyrings/docker-archive-keyring.gpg
+  sudo apt-get install ca-certificates curl gnupg lsb-release -y
+  sudo rm -f /usr/share/keyrings/docker-archive-keyring.gpg
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
   sudo apt-get update
@@ -21,11 +21,11 @@ install_docker () {
 }
 
 create_docker_network () {
-  read -p "Choose the name for your custome docker network (ex. ibranet) : " customnetwork
+  read -p "Choose the name for your custom docker network (ex. ibranet) : " customnetwork
   customnetwork=${customnetwork:-ibranet}
   sed -i "s/^dockernet=.*$/dockernet=$customnetwork/" /opt/ibracorp/ibramenu/.profile
 
-  docker network create $customnetwork > /dev/null 2>&1
+  docker network create "$customnetwork" > /dev/null 2>&1
 }
 
 install_docker

--- a/MenuOptions/Submenu Docker/Basic Docker Control/Basic Docker Control.sh
+++ b/MenuOptions/Submenu Docker/Basic Docker Control/Basic Docker Control.sh
@@ -68,9 +68,8 @@ docker_control() {
     cd /opt/appdata
     for file in *; do
         msgbox "Docker Container $file"
-        docker_c=("$docker_c[@]}" "$file")
         if [ -d "$file" ]; then
-            cd $file
+            cd "$file"
             docker compose $1
             cd ..
         fi

--- a/MenuOptions/Submenu Media Services/Submenu The ARRs/Whisparr/Whisparr.sh
+++ b/MenuOptions/Submenu Media Services/Submenu The ARRs/Whisparr/Whisparr.sh
@@ -10,7 +10,7 @@
 source /opt/ibracorp/ibramenu/ibrafunc.sh
 
 # App Info
-app="whiasparr"                                # App Name
+app="whisparr"                                 # App Name
 title="Whisparr"                               # Readable App Title
 image="ghcr.io/hotio/whisparr"    # Image and Tag
 volumes="    volumes:

--- a/MenuOptions/Submenu Security/Clamav/Clamav.sh
+++ b/MenuOptions/Submenu Security/Clamav/Clamav.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ######################################################################
-# Title   : Install Komga
+# Title   : Install Clamav
 # By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™

--- a/MenuOptions/Submenu Tools/FreshRSS/FreshRSS.sh
+++ b/MenuOptions/Submenu Tools/FreshRSS/FreshRSS.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ######################################################################
-# Title   : Install Komga
+# Title   : Install FreshRSS
 # By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
 # Another fine product brought to you by IBRACORP™
@@ -15,7 +15,7 @@ title="FreshRSS"                            # Readable App Title
 image="lscr.io/linuxserver/freshrss:latest" # Image and Tag
 volumes="    volumes:
       - /opt/appdata/\${APP_NAME:?err}:/config" # Volumes
-tp_app="Plex"                                   # Theme Park App Name
+tp_app="freshrss"                                # Theme Park App Name
 porte="8040"                                    # External Port
 porti="80"                                      # Internal Port
 extrapayload=""                                 # Extra Payload to add to the Compose

--- a/MenuOptions/Submenu Tools/Linkwarden/Linkwarden.sh
+++ b/MenuOptions/Submenu Tools/Linkwarden/Linkwarden.sh
@@ -31,8 +31,8 @@ extrapayload="    environment:
 
 appcreate_local() {
     msgbox "Installing $title..."
-    mkdir -p /opt/appdata/$app && cd /opt/appdata/$app
-    rm compose.yaml
+    mkdir -p "/opt/appdata/$app" && cd "/opt/appdata/$app"
+    rm -f compose.yaml
     tee <<-EOF >.env
 APP_NAME=$app
 IMAGE=$image

--- a/ibrafunc.sh
+++ b/ibrafunc.sh
@@ -10,7 +10,9 @@
 
 # profile file
 source /opt/ibracorp/ibramenu/.profile
-source /opt/appdata/.traefik.env
+if [ -f /opt/appdata/.traefik.env ]; then
+  source /opt/appdata/.traefik.env
+fi
 
 if [[ -n "${IBRAMENU_DOCKER_NETWORK:-}" ]]; then
   dockernet="$IBRAMENU_DOCKER_NETWORK"
@@ -128,7 +130,7 @@ $stamp
 EOF
       ;;
     *)
-      echo "IBRACROP Disclaimer has not been accepted. Exiting..."
+      echo "IBRACORP Disclaimer has not been accepted. Exiting..."
       echo
       exit 0
       ;;
@@ -181,7 +183,7 @@ environment_check() {
 # launch docker compose container
 launchdocker() {
   target_folder=$1
-  if [ ! -d $target_folder ]; then
+  if [ ! -d "$target_folder" ]; then
     mkdir -p "$target_folder"
   fi
   cp -R * "$target_folder"
@@ -216,26 +218,26 @@ checkupdate() {
 
 # IBRACORP motd
 ibramotd() {
-  chmod -x /etc/update-motd.d/*
-  tee <<-'EOF' >/etc/update-motd.d/01-ibracorp
+  if [ -d /etc/update-motd.d ]; then
+    chmod -x /etc/update-motd.d/* 2>/dev/null || true
+  fi
+  cat >/etc/update-motd.d/01-ibracorp <<'MOTDSCRIPT'
 #!/bin/bash
 ######################################################################
 # Title   : IBRACORP MOTD
 # By      : Sycotix, DiscDuck, Taos15
 # License : General Public License GPL-3.0-or-later
-# Another fine product brought to you by IBRACORP   ^d
+# Another fine product brought to you by IBRACORP
 ######################################################################
-tee <<-EOF
-  ___ ____  ____      _    ____ ___  ____  ____     (tm)
- |_ _| __ )|  _ \    / \  / ___/ _ \|  _ \|  _ \
-  | ||  _ \| |_) |  / _ \| |  | | | | |_) | |_) |
-  | || |_) |  _ <  / ___ \ |__| |_| |  _ <|  __/
- |___|____/|_| \_\/_/   \_\____\___/|_| \_\_|
-$(lsb_release -sd) | CPU Threads: $(lscpu | grep "CPU(s):" | tail +1 | head -1 | awk  '{print $2}') | IP: $(hostname -I | awk '{print $1}') | RAM: $(free -m | grep Mem | awk 'NR=1 {print $2}') MB
-Become a Member and sponsor us: https://ibracorp.io/memberships
-Type 'ibramenu' to launch IBRAMENU.
-EOF
-  echo "EOF" >>/etc/update-motd.d/01-ibracorp
+echo "  ___ ____  ____      _    ____ ___  ____  ____     (tm)"
+echo " |_ _| __ )|  _ \    / \  / ___/ _ \|  _ \|  _ \ "
+echo "  | ||  _ \| |_) |  / _ \| |  | | | | |_) | |_) |"
+echo "  | || |_) |  _ <  / ___ \ |__| |_| |  _ <|  __/ "
+echo " |___|____/|_| \_\/_/   \_\____\___/|_| \_\_|    "
+echo "$(lsb_release -sd 2>/dev/null || echo Linux) | CPU Threads: $(nproc) | IP: $(hostname -I | awk '{print $1}') | RAM: $(free -m | awk '/Mem/{print $2}') MB"
+echo "Become a Member and sponsor us: https://ibracorp.io/memberships"
+echo "Type 'ibramenu' to launch IBRAMENU."
+MOTDSCRIPT
   chmod +x /etc/update-motd.d/01-ibracorp
 }
 
@@ -248,7 +250,7 @@ appgreetings() {
 # App
 appcreate() {
   msgbox "Installing $title..."
-  mkdir -p /opt/appdata/$app && cd /opt/appdata/$app
+  mkdir -p "/opt/appdata/$app" && cd "/opt/appdata/$app"
   tee <<-EOF >.env
 APP_NAME=$app
 IMAGE=$image

--- a/ibramenu.sh
+++ b/ibramenu.sh
@@ -30,7 +30,7 @@ menu_from_array() {
       break
       ;;
     b | B)
-      if [ "$PWD/" = $menu_entry_point ]; then
+      if [ "$PWD/" = "$menu_entry_point" ]; then
         read -p "Already at Top Menu. Press enter to continue..."
         break
       else
@@ -68,7 +68,7 @@ execute_script() {
 }
 
 # Define Variables
-if [ $1 ]; then
+if [ -n "${1-}" ]; then
   menu_entry_point="$1"
 else
   menu_entry_point="/opt/ibracorp/ibramenu/MenuOptions/"
@@ -85,7 +85,8 @@ environment_check
 ibramotd
 
 # Menu
-until [ $REPLY = x ] || [ $REPLY = X ]; do
+REPLY=""
+until [ "$REPLY" = x ] || [ "$REPLY" = X ]; do
   ibralogo
   checkupdate
   unset menu_choice


### PR DESCRIPTION
Core startup bugs:
- ibrafunc.sh: Guard sourcing of .traefik.env with existence check to prevent crash on first run when the file hasn't been created yet
- ibramenu.sh: Initialize REPLY variable before until loop to prevent "unary operator expected" error on startup
- ibramenu.sh: Quote $menu_entry_point and use safe ${1-} parameter expansion to prevent errors with spaces and missing arguments

ibrafunc.sh fixes:
- Fix "IBRACROP" typo in disclaimer rejection message (should be IBRACORP)
- Quote $target_folder in launchdocker() to handle paths with spaces
- Rewrite ibramotd() to fix broken nested heredoc that produced a malformed MOTD script; also guard chmod -x against missing directory
- Quote path in appcreate() mkdir/cd for app names with spaces

MenuOptions fixes:
- Basic Docker Control.sh: Remove broken array syntax docker_c=("$docker_c[@]}" ...) and quote $file in cd
- Whisparr.sh: Fix app name typo "whiasparr" -> "whisparr"
- FreshRSS.sh: Fix wrong title comment "Komga" -> "FreshRSS" and wrong tp_app "Plex" -> "freshrss"
- Clamav.sh: Fix wrong title comment "Komga" -> "Clamav"
- General Tools.sh: Add missing -y flag to apt-get install gcc python3-dev to prevent interactive hang
- Install Docker.sh: Use rm -f to avoid error when keyring doesn't exist, add -y to apt-get install, fix "custome" typo, quote $customnetwork
- Linkwarden.sh: Use rm -f for compose.yaml, quote paths with $app